### PR TITLE
Leave the option to disable item per page

### DIFF
--- a/upload/catalog/controller/product/pdf_catalog.php
+++ b/upload/catalog/controller/product/pdf_catalog.php
@@ -333,7 +333,7 @@ class ControllerProductPdfcatalog extends Controller {
 
                         $tmp_products .= $tmp_product;
                         $no_of_item++;
-                        if (($no_of_item + 1) > $item_per_page) {
+                        if ($item_per_page > 0 && ($no_of_item + 1) > $item_per_page) {
                             $pdf_content .= str_replace("{::products}", $tmp_products, $tmp_category) . '<div class="page_break"></div>';
                             $tmp_products = "";
                             $no_of_item = 0;


### PR DESCRIPTION
Item per page is mostly broken if you don't properly find the image size and description size that matches with your configured items per page, so why not just disabling it and let the PDF library care about page limits.
